### PR TITLE
Tracker frame can no longer disappear off-screen

### DIFF
--- a/Todoloo/Source/Display/Tracker.xml
+++ b/Todoloo/Source/Display/Tracker.xml
@@ -318,7 +318,7 @@ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/FrameXML/UI
         Frame resembling Blizzard ObjectiveTrackerFrame.
         This frame is our main tracker frame, which resembles the games objective frame with quests.
     -->
-    <Frame name="TodolooTrackerFrame" inherits="UIParentRightManagedFrameTemplate" movable="true" frameStrata="LOW" resizable="true">
+    <Frame name="TodolooTrackerFrame" inherits="UIParentRightManagedFrameTemplate" movable="true" clampedToScreen="true" frameStrata="LOW">
         <Size x="235" y="500" />
 		<ResizeBounds>
 			<minResize x="235" y="140" />


### PR DESCRIPTION
Sometime the task tracker frame would disappear off-screen. This has been solved by clamping the tracker frame to the screen.

#21