### PR TITLE
(#24) Ensure that task tracker does not disappear off-screen

### DIFF
--- a/Todoloo/Source/Display/Tracker.lua
+++ b/Todoloo/Source/Display/Tracker.lua
@@ -888,8 +888,6 @@ function TodolooTrackerGroupHeader_OnLoad(self)
 end
 
 function TodolooTracker_OnShow(self)
-    UIParentManagedFrameMixin.OnShow(self);
-
     Todoloo.EventBus:RegisterEvents(self, {
         Todoloo.Tasks.Events.GROUP_ADDED,
         Todoloo.Tasks.Events.GROUP_REMOVED,
@@ -903,7 +901,7 @@ function TodolooTracker_OnShow(self)
         Todoloo.Reset.Events.RESET_PERFORMED
     }, TodolooTracker_ReceiveEvent)
     
-    --TODO: Set height based on Todoloo config
+    --TODO: Set max height based on Todoloo config
     --TodolooTracker_UpdateHeight()
 end
 

--- a/Todoloo/Source/Display/Tracker.xml
+++ b/Todoloo/Source/Display/Tracker.xml
@@ -318,7 +318,7 @@ https://raw.githubusercontent.com/Gethe/wow-ui-source/live/Interface/FrameXML/UI
         Frame resembling Blizzard ObjectiveTrackerFrame.
         This frame is our main tracker frame, which resembles the games objective frame with quests.
     -->
-    <Frame name="TodolooTrackerFrame" inherits="UIParentRightManagedFrameTemplate" movable="true" clampedToScreen="true" frameStrata="LOW">
+    <Frame name="TodolooTrackerFrame" parent="UIParent" movable="true" clampedToScreen="true" frameStrata="LOW">
         <Size x="235" y="500" />
 		<Anchors>
 			<Anchor point="TOPLEFT" x="100" y="-150" />


### PR DESCRIPTION
There's no reason to inherit from UIParentRightManagedFrameTemplate or any other tempalte for that matter. I'm pretty sure this is what is causing the task tracker to sporadically disappear off-screen.

#24